### PR TITLE
Add minimal MCTS topology generator

### DIFF
--- a/scripts/run_mcts.py
+++ b/scripts/run_mcts.py
@@ -1,13 +1,32 @@
-"""Run Monte Carlo Tree Search to generate analog topologies.
+"""Run Monte Carlo Tree Search to generate analog topologies."""
+from __future__ import annotations
 
-This script loads trained models and performs guided search to produce
-candidate circuit designs.
-"""
+from pprint import pprint
+import sys
+from pathlib import Path
+
+# Ensure the src/ directory is importable when running from a source checkout
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
+
+from topozero.core.state import EulerState
+from topozero.mcts.puct import PUCT
+from topozero.mcts import reward
+
+# A tiny example adjacency graph forming an Eulerian circuit.
+ADJACENCY = {
+    "NM1_D": ["R1_P", "NM1_S"],
+    "R1_P": ["NM1_D", "R1_N"],
+    "R1_N": ["R1_P", "NM1_S"],
+    "NM1_S": ["R1_N", "NM1_D"],
+}
 
 
 def main() -> None:
-    """Entry point for running MCTS."""
-    pass
+    state = EulerState(start_pin="NM1_D", adjacency=ADJACENCY)
+    searcher = PUCT(n_simulations=100, seed=0)
+    final_state = searcher.search(state)
+    pprint(final_state.path)
+    print("reward:", reward.evaluate(final_state))
 
 
 if __name__ == "__main__":

--- a/src/topozero/core/actions.py
+++ b/src/topozero/core/actions.py
@@ -1,10 +1,19 @@
-"""Action utilities for modifying :class:`State` objects."""
+"""Action utilities for manipulating :class:`EulerState` objects."""
+from __future__ import annotations
 
 from typing import List
 
-from .state import State
+from .state import EulerState
 
 
-def available_actions(state: State) -> List[str]:
-    """Return a list of available actions from the given state."""
-    return []
+def available_actions(state: EulerState) -> List[str]:
+    """Return the list of legal actions from ``state``.
+
+    This is a thin wrapper around :meth:`EulerState.legal_actions` so the
+    function mirrors the interface used in the placeholder project.
+    """
+
+    return state.legal_actions()
+
+
+__all__ = ["available_actions"]

--- a/src/topozero/core/state.py
+++ b/src/topozero/core/state.py
@@ -1,20 +1,101 @@
-"""State representation for circuit topologies.
+"""State representation for Eulerian traversal of a circuit graph.
 
-The :class:`State` object captures the current graph of components and
-connections during the search process.
+The :class:`EulerState` keeps track of the current pin in the traversal,
+which edges have already been used, and provides helpers for generating legal
+moves.  Edges are considered undirected; once an edge between two pins has been
+visited it cannot be traversed again.
 """
-
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import Any
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Set, Tuple
+
+END_TOKEN = "END"
 
 
 @dataclass
-class State:
-    """A minimal state placeholder."""
+class EulerState:
+    """State of an Eulerian trail over a pin-level graph."""
 
-    data: Any = None
+    start_pin: str
+    adjacency: Dict[str, List[str]]
+    current_pin: str | None = None
+    visited_edges: Set[Tuple[str, str]] = field(default_factory=set)
+    path: List[str] = field(default_factory=list)
 
-    def clone(self) -> "State":
-        """Return a copy of the state."""
-        return State(self.data)
+    def __post_init__(self) -> None:
+        if self.current_pin is None:
+            self.current_pin = self.start_pin
+        if not self.path:
+            self.path.append(self.current_pin)
+        # Pre-compute the set of all edges in the undirected graph.
+        self._all_edges: Set[Tuple[str, str]] = set()
+        for a, neighbours in self.adjacency.items():
+            for b in neighbours:
+                edge = self._canonical_edge(a, b)
+                self._all_edges.add(edge)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _canonical_edge(a: str, b: str) -> Tuple[str, str]:
+        """Return a canonical representation for an undirected edge."""
+        return (a, b) if a <= b else (b, a)
+
+    # ------------------------------------------------------------------
+    def clone(self) -> "EulerState":
+        """Return a deep copy of the state."""
+        return EulerState(
+            start_pin=self.start_pin,
+            adjacency=self.adjacency,
+            current_pin=self.current_pin,
+            visited_edges=set(self.visited_edges),
+            path=list(self.path),
+        )
+
+    # ------------------------------------------------------------------
+    def legal_actions(self) -> List[str]:
+        """Return the list of legal next pins or [END_TOKEN]."""
+        if self.is_complete():
+            return [END_TOKEN]
+        actions: List[str] = []
+        for nxt in self.adjacency.get(self.current_pin, []):
+            edge = self._canonical_edge(self.current_pin, nxt)
+            if edge not in self.visited_edges:
+                actions.append(nxt)
+        return actions
+
+    # ------------------------------------------------------------------
+    def apply_action(self, action: str) -> None:
+        """Advance the state by taking ``action``.
+
+        Parameters
+        ----------
+        action:
+            Either a neighbour pin to traverse or ``END_TOKEN`` when all edges
+            have been visited.
+        """
+        if action == END_TOKEN:
+            # Terminal action: record the token but keep the current pin so
+            # :meth:`is_complete` remains ``True`` after applying END.
+            self.path.append(END_TOKEN)
+            return
+
+        edge = self._canonical_edge(self.current_pin, action)
+        if edge in self.visited_edges:
+            raise ValueError(f"Edge {edge} has already been visited")
+        self.visited_edges.add(edge)
+        self.current_pin = action
+        self.path.append(action)
+
+    # ------------------------------------------------------------------
+    def is_complete(self) -> bool:
+        """Return ``True`` if all edges have been visited and we are back at the start."""
+        return len(self.visited_edges) == len(self._all_edges) and self.current_pin == self.start_pin
+
+    # ------------------------------------------------------------------
+    @property
+    def total_edges(self) -> int:
+        return len(self._all_edges)
+
+
+__all__ = ["EulerState", "END_TOKEN"]

--- a/src/topozero/core/vocab.py
+++ b/src/topozero/core/vocab.py
@@ -1,0 +1,51 @@
+"""Device pin vocabulary for topology generation.
+
+This module defines the mapping between token strings and integer ids used by
+search and learning components.  The vocabulary is intentionally small for the
+unit tests but mirrors what a larger system would contain.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class Vocabulary:
+    """Bidirectional mapping between tokens and integer ids."""
+
+    tokens: List[str]
+
+    def __post_init__(self) -> None:  # Build lookup tables.
+        self._token_to_id: Dict[str, int] = {tok: i for i, tok in enumerate(self.tokens)}
+        self._id_to_token: Dict[int, str] = {i: tok for tok, i in self._token_to_id.items()}
+
+    def token_to_id(self, token: str) -> int:
+        return self._token_to_id[token]
+
+    def id_to_token(self, idx: int) -> str:
+        return self._id_to_token[idx]
+
+
+# A tiny default vocabulary used in tests.  Real systems would enumerate all
+# device pins and special tokens.
+DEFAULT_TOKENS: List[str] = [
+    "NM1_D",
+    "NM1_G",
+    "NM1_S",
+    "PM1_D",
+    "PM1_G",
+    "PM1_S",
+    "R1_P",
+    "R1_N",
+    "C1_P",
+    "C1_N",
+    "VDD",
+    "VSS",
+    # Special token signalling that the Euler trail has covered all edges.
+    "END",
+]
+
+DEFAULT_VOCAB = Vocabulary(DEFAULT_TOKENS)
+
+__all__ = ["Vocabulary", "DEFAULT_TOKENS", "DEFAULT_VOCAB"]

--- a/src/topozero/mcts/netlist_export.py
+++ b/src/topozero/mcts/netlist_export.py
@@ -1,0 +1,17 @@
+"""Utilities for exporting token sequences to SPICE netlists.
+
+For the purposes of the unit tests this module simply joins the token sequence
+into a string representing the netlist.  It acts as a placeholder for a more
+complete exporter that would understand component connectivity.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def tokens_to_netlist(tokens: Iterable[str]) -> str:
+    """Convert an iterable of tokens to a mock netlist string."""
+    return "\n".join(tokens)
+
+
+__all__ = ["tokens_to_netlist"]

--- a/src/topozero/mcts/puct.py
+++ b/src/topozero/mcts/puct.py
@@ -1,14 +1,123 @@
-"""PUCT algorithm for guiding Monte Carlo Tree Search."""
-
+"""Minimal PUCT-based Monte Carlo Tree Search implementation."""
 from __future__ import annotations
-from typing import Any
 
-from ..core.state import State
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+import math
+import random
+
+from ..core.state import END_TOKEN, EulerState
+from ..core.actions import available_actions
+from . import reward as reward_module
+
+
+@dataclass
+class Node:
+    state: EulerState
+    parent: Optional[Node] = None
+    prior: float = 1.0
+    children: Dict[str, Node] = field(default_factory=dict)
+    visit_count: int = 0
+    total_value: float = 0.0
+
+    # ------------------------------------------------------------------
+    def is_expanded(self) -> bool:
+        return bool(self.children)
+
+    # ------------------------------------------------------------------
+    def q_value(self) -> float:
+        if self.visit_count == 0:
+            return 0.0
+        return self.total_value / self.visit_count
+
+    # ------------------------------------------------------------------
+    def expand(self) -> None:
+        actions = available_actions(self.state)
+        if not actions:
+            return
+        prob = 1.0 / len(actions)
+        for action in actions:
+            next_state = self.state.clone()
+            next_state.apply_action(action)
+            self.children[action] = Node(state=next_state, parent=self, prior=prob)
+
+    # ------------------------------------------------------------------
+    def select_child(self, c_puct: float) -> Node:
+        """Select a child with maximum PUCT value."""
+        best_score = -float("inf")
+        best_action = None
+        for action, child in self.children.items():
+            u = c_puct * child.prior * math.sqrt(self.visit_count) / (1 + child.visit_count)
+            q = child.q_value()
+            score = q + u
+            if score > best_score or (score == best_score and (best_action is None or action < best_action)):
+                best_score = score
+                best_action = action
+        return self.children[best_action]
+
+    # ------------------------------------------------------------------
+    def best_child(self) -> Node:
+        return max(self.children.values(), key=lambda n: n.visit_count)
 
 
 class PUCT:
-    """Placeholder for the PUCT search algorithm."""
+    """PUCT searcher with simple rollouts and reward function."""
 
-    def search(self, root: State) -> Any:
-        """Perform a search starting from ``root`` and return a result."""
-        pass
+    def __init__(self, c_puct: float = 1.0, n_simulations: int = 50, seed: int | None = 0):
+        self.c_puct = c_puct
+        self.n_simulations = n_simulations
+        self.rng = random.Random(seed)
+
+    # ------------------------------------------------------------------
+    def _rollout(self, state: EulerState) -> float:
+        """Run a random rollout until ``END_TOKEN`` and return reward."""
+        sim_state = state.clone()
+        while True:
+            actions = available_actions(sim_state)
+            if not actions:
+                break
+            action = self.rng.choice(actions)
+            sim_state.apply_action(action)
+            if action == END_TOKEN:
+                break
+        return reward_module.evaluate(sim_state)
+
+    # ------------------------------------------------------------------
+    def search(self, root_state: EulerState) -> EulerState:
+        root = Node(state=root_state.clone())
+
+        for _ in range(self.n_simulations):
+            node = root
+            # Selection
+            while node.is_expanded() and node.state.legal_actions() and not node.state.is_complete():
+                node = node.select_child(self.c_puct)
+            # Expansion
+            if not node.state.is_complete():
+                node.expand()
+                if node.children:
+                    node = node.select_child(self.c_puct)
+            # Simulation
+            value = self._rollout(node.state)
+            # Backup
+            while node is not None:
+                node.visit_count += 1
+                node.total_value += value
+                node = node.parent
+
+        # Choose the most visited child to produce final sequence
+        if not root.children:
+            return root.state
+        node = root.best_child()
+        while not node.state.is_complete():
+            if not node.children:
+                node.expand()
+            if not node.children:
+                break
+            node = node.best_child()
+        # Append END if needed
+        if END_TOKEN not in node.state.path:
+            if node.state.is_complete():
+                node.state.apply_action(END_TOKEN)
+        return node.state
+
+__all__ = ["PUCT"]

--- a/src/topozero/mcts/reward.py
+++ b/src/topozero/mcts/reward.py
@@ -1,0 +1,17 @@
+"""Placeholder reward function for circuit evaluation.
+
+The real project would export the generated circuit to a SPICE netlist and run
+PySpice simulations.  For unit tests we simply return ``1.0`` when the Euler
+trail is complete and ``0.0`` otherwise.
+"""
+from __future__ import annotations
+
+from ..core.state import EulerState
+
+
+def evaluate(state: EulerState) -> float:
+    """Return a heuristic reward for ``state``."""
+    return 1.0 if state.is_complete() else 0.0
+
+
+__all__ = ["evaluate"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Add the src directory to PYTHONPATH so tests can import topozero package
+SRC_PATH = Path(__file__).resolve().parent.parent / "src"
+if SRC_PATH not in map(Path, sys.path):
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -1,12 +1,23 @@
-"""Tests for the :mod:`topozero.mcts.puct` module."""
-
-from topozero.core.state import State
+"""Tests for the PUCT search implementation."""
+from topozero.core.state import EulerState
 from topozero.mcts.puct import PUCT
+from topozero.mcts import reward
+
+ADJACENCY = {
+    "NM1_D": ["R1_P", "NM1_S"],
+    "R1_P": ["NM1_D", "R1_N"],
+    "R1_N": ["R1_P", "NM1_S"],
+    "NM1_S": ["R1_N", "NM1_D"],
+}
 
 
-def test_puct_search_runs() -> None:
-    """PUCT.search should run without errors and return ``None`` for now."""
-    state = State()
-    searcher = PUCT()
-    result = searcher.search(state)
-    assert result is None
+def test_puct_finds_complete_path() -> None:
+    state = EulerState(start_pin="NM1_D", adjacency=ADJACENCY)
+    searcher = PUCT(n_simulations=50, seed=0)
+    final_state = searcher.search(state)
+    assert final_state.is_complete()
+    assert final_state.path[0] == "NM1_D"
+    assert final_state.path[-1] == "END"
+    assert reward.evaluate(final_state) == 1.0
+    # start + number_of_edges + END
+    assert len(final_state.path) == final_state.total_edges + 2

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,11 +1,26 @@
-"""Tests for the :mod:`topozero.core.state` module."""
+"""Tests for the EulerState class."""
+from topozero.core.state import END_TOKEN, EulerState
 
-from topozero.core.state import State
+ADJACENCY = {
+    "NM1_D": ["R1_P", "NM1_S"],
+    "R1_P": ["NM1_D", "R1_N"],
+    "R1_N": ["R1_P", "NM1_S"],
+    "NM1_S": ["R1_N", "NM1_D"],
+}
 
 
-def test_state_clone() -> None:
-    """State.clone should return a new State instance."""
-    s = State(data=123)
-    clone = s.clone()
-    assert isinstance(clone, State)
-    assert clone.data == 123
+def test_state_clone_and_traversal() -> None:
+    state = EulerState(start_pin="NM1_D", adjacency=ADJACENCY)
+    clone = state.clone()
+    clone.apply_action("R1_P")
+    # Original state should remain unchanged
+    assert state.current_pin == "NM1_D"
+    assert set(state.legal_actions()) == {"R1_P", "NM1_S"}
+
+    # Traverse an entire Euler circuit
+    state.apply_action("R1_P")
+    state.apply_action("R1_N")
+    state.apply_action("NM1_S")
+    state.apply_action("NM1_D")
+    assert state.is_complete()
+    assert state.legal_actions() == [END_TOKEN]


### PR DESCRIPTION
## Summary
- define device-pin vocabulary and EulerState for pin-level graph traversal
- implement PUCT-based Monte Carlo Tree Search with placeholder reward and netlist export
- add script and tests demonstrating end-to-end search over a tiny circuit

## Testing
- `pytest -q`
- `python scripts/run_mcts.py`


------
https://chatgpt.com/codex/tasks/task_e_6897de13252083238ebafe0a12629d5c